### PR TITLE
Added baseline link prediction algorithm

### DIFF
--- a/src/graph/knowledge_graph.py
+++ b/src/graph/knowledge_graph.py
@@ -6,7 +6,7 @@ from langchain_neo4j.graphs.graph_document import GraphDocument
 from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
 from langchain_neo4j.vectorstores.neo4j_vector import Neo4jVector
 from neo4j import ManagedTransaction
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from src.config import KnowledgeGraphConfig
 from src.graph.graph_model import Community, CommunityReport
@@ -613,6 +613,74 @@ class KnowledgeGraph(Neo4jGraph):
             self.update_properties(G, centralities, ld, lv, leiden_mod, louvain_mod)
         except Exception as e:
             logger.warning(f"Something went wrong while updating properties on graph nodes: {e}")
+
+
+    def predict_links(
+        self,
+        method: str = "adamic_adar",
+        top_k: int = 10,
+        entity_only: bool = True
+    ) -> List[Tuple[str, str, float]]:
+        """
+        Predicts missing or future links between entities in the Knowledge Graph.
+        
+        Uses baseline heuristic methods to identify potential relationships between
+        nodes that are not currently connected.
+        
+        Parameters:
+        -----------
+        method : str
+            Link prediction algorithm to use. Options:
+            - 'common_neighbors': Count of shared neighbors
+            - 'jaccard': Jaccard similarity of neighborhoods  
+            - 'adamic_adar': Adamic-Adar index (default, weights rare connections higher)
+            - 'preferential_attachment': Product of node degrees (rich-get-richer)
+        top_k : int
+            Number of top-ranked predictions to return (default: 10)
+        entity_only : bool
+            If True, only predict links between __Entity__ nodes, excluding
+            Document, Chunk, and other metadata nodes (default: True)
+            
+        Returns:
+        --------
+        List[Tuple[str, str, float]]
+            List of (source_id, target_id, score) tuples, ranked by prediction score
+            
+        Example:
+        --------
+        >>> predictions = kg.predict_links(method="adamic_adar", top_k=10)
+        >>> for src, tgt, score in predictions:
+        ...     print(f"{src} -> {tgt}: {score:.4f}")
+        """
+        from src.graph.link_prediction import predict_links as lp_predict_links
+        
+        # Get NetworkX representation of the graph
+        G = self.get_digraph()
+        
+        # Filter to entity nodes if requested
+        node_filter = None
+        if entity_only:
+            # Only consider nodes with __Entity__ label
+            entity_nodes = {
+                node_id for node_id, data in G.nodes(data=True)
+                if BASE_ENTITY_LABEL in data.get("labels", [])
+            }
+            node_filter = entity_nodes
+            logger.info(f"Filtering to {len(entity_nodes)} entity nodes for link prediction")
+        
+        # Run link prediction
+        predictions = lp_predict_links(
+            G=G,
+            method=method,
+            top_k=top_k,
+            exclude_existing=True,
+            node_filter=node_filter
+        )
+        
+        logger.info(f"Generated {len(predictions)} link predictions using {method} method")
+        
+        return predictions
+
 
 
     def get_communities(self, comm_type: str = "leiden") -> List[Community]:

--- a/src/graph/link_prediction.py
+++ b/src/graph/link_prediction.py
@@ -1,0 +1,153 @@
+"""
+Link prediction algorithms for discovering new relations between entities.
+
+This module implements baseline heuristic methods for predicting missing or 
+future links in a knowledge graph. All methods operate on NetworkX graphs.
+"""
+
+import networkx as nx
+from typing import List, Tuple, Optional, Set
+from src.utils.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def common_neighbors(G: nx.Graph, u: str, v: str) -> float:
+    """
+    Count the number of common neighbors between two nodes.
+    
+    Higher scores indicate nodes with more shared connections.
+    """
+    neighbors_u = set(G.neighbors(u))
+    neighbors_v = set(G.neighbors(v))
+    return float(len(neighbors_u & neighbors_v))
+
+
+def jaccard_coefficient(G: nx.Graph, u: str, v: str) -> float:
+    """
+    Compute Jaccard similarity between node neighborhoods.
+    
+    Normalizes common neighbors by the size of the union of neighborhoods.
+    Returns value between 0 and 1.
+    """
+    neighbors_u = set(G.neighbors(u))
+    neighbors_v = set(G.neighbors(v))
+    
+    intersection = neighbors_u & neighbors_v
+    union = neighbors_u | neighbors_v
+    
+    if len(union) == 0:
+        return 0.0
+    
+    return len(intersection) / len(union)
+
+
+def adamic_adar_index(G: nx.Graph, u: str, v: str) -> float:
+    """
+    Compute Adamic-Adar index between two nodes.
+    
+    Weights common neighbors by the inverse log of their degree.
+    Rare connections are weighted more heavily than common ones.
+    """
+    neighbors_u = set(G.neighbors(u))
+    neighbors_v = set(G.neighbors(v))
+    common = neighbors_u & neighbors_v
+    
+    score = 0.0
+    for neighbor in common:
+        degree = G.degree(neighbor)
+        if degree > 1:
+            score += 1.0 / (degree ** 0.5)  # Using sqrt instead of log for numerical stability
+    
+    return score
+
+
+def preferential_attachment(G: nx.Graph, u: str, v: str) -> float:
+    """
+    Compute preferential attachment score (product of node degrees).
+    
+    Implements the "rich get richer" principle - high-degree nodes 
+    are more likely to form connections.
+    """
+    return float(G.degree(u) * G.degree(v))
+
+
+def predict_links(
+    G: nx.DiGraph,
+    method: str = "adamic_adar",
+    top_k: int = 10,
+    exclude_existing: bool = True,
+    node_filter: Optional[Set[str]] = None
+) -> List[Tuple[str, str, float]]:
+    """
+    Predict missing or future links in a directed graph.
+    
+    Parameters:
+    -----------
+    G : nx.DiGraph
+        The directed graph to analyze
+    method : str
+        Link prediction method to use. Options:
+        - 'common_neighbors': Count shared neighbors
+        - 'jaccard': Jaccard similarity of neighborhoods
+        - 'adamic_adar': Adamic-Adar index (default)
+        - 'preferential_attachment': Product of node degrees
+    top_k : int
+        Number of top predictions to return (default: 10)
+    exclude_existing : bool
+        If True, exclude existing edges from predictions (default: True)
+    node_filter : Optional[Set[str]]
+        If provided, only consider node pairs within this set
+        
+    Returns:
+    --------
+    List[Tuple[str, str, float]]
+        List of (source_node, target_node, score) tuples, sorted by score descending
+    """
+    # Convert to undirected for link prediction (treat graph as symmetric)
+    G_undirected = G.to_undirected()
+    
+    # Select scoring function
+    score_functions = {
+        "common_neighbors": common_neighbors,
+        "jaccard": jaccard_coefficient,
+        "adamic_adar": adamic_adar_index,
+        "preferential_attachment": preferential_attachment
+    }
+    
+    if method not in score_functions:
+        raise ValueError(f"Unknown method: {method}. Choose from {list(score_functions.keys())}")
+    
+    score_fn = score_functions[method]
+    
+    # Get nodes to consider
+    nodes = list(node_filter) if node_filter else list(G_undirected.nodes())
+    
+    # Get existing edges (for exclusion)
+    existing_edges = set()
+    if exclude_existing:
+        for u, v in G_undirected.edges():
+            existing_edges.add((u, v))
+            existing_edges.add((v, u))  # Both directions for undirected
+    
+    # Compute scores for all non-connected node pairs
+    predictions = []
+    for i, u in enumerate(nodes):
+        for v in nodes[i+1:]:  # Only consider each pair once
+            # Skip if edge already exists
+            if exclude_existing and ((u, v) in existing_edges or (v, u) in existing_edges):
+                continue
+            
+            # Compute score
+            try:
+                score = score_fn(G_undirected, u, v)
+                if score > 0:  # Only include non-zero scores
+                    predictions.append((u, v, score))
+            except Exception as e:
+                logger.warning(f"Error computing {method} for ({u}, {v}): {e}")
+    
+    # Sort by score descending and return top k
+    predictions.sort(key=lambda x: x[2], reverse=True)
+    
+    return predictions[:top_k]


### PR DESCRIPTION
This PR adds a simple link prediction feature to the repo

It implements a few standard graph heuristics (common neighbor, Jaccard, Adamic–Adar, preferential attachment) to suggest possible missing links between existing nodes

The implementation:
- works on the existing NetworkX graph representation
- is purely additive
- does not modify stored graph data or introduce new dependencies

Closes #18 